### PR TITLE
Round abv to 1dp on drinks board

### DIFF
--- a/fe/src/BoardFolder/TheBoard.js
+++ b/fe/src/BoardFolder/TheBoard.js
@@ -107,7 +107,7 @@ const TheBoard =({ drinkers, drinkTypes }) => {
           <tr key={index}>
             <td>{drink.name}</td>
             <td>{!drink.date ? "Awaiting Verdict" : moment(drink.date).format('h:mma')}</td>
-            <td>{drink.drinkMain} {drink.abv ? `(${drink.abv*100}%)` : `(???)`}</td>
+            <td>{drink.drinkMain} {drink.abv ? `(${(drink.abv*100).toPrecision(2)}%)` : `(???)`}</td>
             <td> {drink.ukUsa ? `${drink.company} (${drink.ukUsa})`
                                     : drink.country ? `${drink.company} (${drink.country})`
                                     : `${drink.company} (???)`}


### PR DESCRIPTION
Caveat: I haven't actually tested this beyond running this in a console:

```javascript
// ABV returned from backend is 0.07
// 0.07*100
7.000000000000001

// (0.07*100).toPrecision(2)
"7.0"
```

Basically, running calculations on floats is a clusterfuck, so as soon as you try and do anything you end up with precision errors because floats are (by design) imprecise. So you just always need to round them after you do a calculation or use a different datatype (decimal/numeric/something else depending on the language; can't remember what it is for javascript... some googling might provide an answer).

This is why you have to be careful if you ever do anything with money, as you'll add two numbers together or apply an 80% offer to a checkout or whatever and end up with unrealistic numbers. There are a **ton** of unnecessarily crazy blogposts about this if you google for "why do floats have rounding errors", but this one seems fairly good (second caveat: I've only skim-read couple of sections): https://blog.penjee.com/what-are-floating-point-errors-answered/